### PR TITLE
Fix `thread` module import on Python 2.7

### DIFF
--- a/functools32/_dummy_thread32.py
+++ b/functools32/_dummy_thread32.py
@@ -6,7 +6,10 @@ not need to be rewritten for when the thread module is not present.
 Suggested usage is::
 
     try:
-        import _thread
+        try:
+            import _thread  # Python >= 3
+        except:
+            import thread as _thread  # Python < 3
     except ImportError:
         import _dummy_thread as _thread
 

--- a/functools32/functools32.py
+++ b/functools32/functools32.py
@@ -17,8 +17,8 @@ from .reprlib32 import recursive_repr as _recursive_repr
 from weakref import proxy as _proxy
 import sys as _sys
 try:
-    from _thread import allocate_lock as Lock
-except:
+    from thread import allocate_lock as Lock
+except ImportError:
     from ._dummy_thread32 import allocate_lock as Lock
 
 ################################################################################

--- a/functools32/reprlib32.py
+++ b/functools32/reprlib32.py
@@ -5,7 +5,7 @@ __all__ = ["Repr", "repr", "recursive_repr"]
 import __builtin__ as builtins
 from itertools import islice
 try:
-    from _thread import get_ident
+    from thread import get_ident
 except ImportError:
     from _dummy_thread32 import get_ident
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def main():
 
     setup(
       name='functools32',
-      version='3.2.3-1',
+      version='3.2.3-2',
       description='Backport of the functools module from Python 3.2.3 for use on 2.7 and PyPy.',
       long_description="""
 This is a backport of the functools standard library module from


### PR DESCRIPTION
The Python 2.7 `thread` module has been renamed to `_thread` in
Python3. This package was importing the `_thread` anyway, and was thus
fallbacking to the `dummy_thread32` module everytime, which is far from
failproof (eg. `lru_cache` decorator used in a WSGI app started on uWSGI
with threads enabled and high concurrency raises exceptions).

This fix loads the `thread` module accordingly, without trying to load
Python3 `_thread` module since setup.py prevents installation on Python 3 explicitly.