### PR TITLE
Added trove classifiers to setup.setup()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,7 @@ new features `lru_cache` (Least-recently-used cache decorator).""",
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 2 :: Only'
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ),

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,22 @@ This is a backport of the functools standard library module from
 Python 3.2.3 for use on Python 2.7 and PyPy. It includes
 new features `lru_cache` (Least-recently-used cache decorator).""",
       license='PSF license',
+      classifiers=(
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'License :: OSI Approved :: Python Software Foundation License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy'
+    ),
 
       maintainer='ENDOH takanao',
       maintainer_email='djmchl@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ new features `lru_cache` (Least-recently-used cache decorator).""",
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 2 :: Only'
+        'Programming Language :: Python :: 2 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ),


### PR DESCRIPTION
Indicates support for both Python 2 and Python 3.

Similar changes should be made to https://pypi.python.org/pypi/functools32 to avoid being listed as `red` on http://python3wos.appspot.com/

Full list of trove classifiers https://pypi.python.org/pypi?%3Aaction=list_classifiers
